### PR TITLE
Allow stubbing and setting return values on properties that may or may not yet be defined.

### DIFF
--- a/bond.coffee
+++ b/bond.coffee
@@ -86,9 +86,6 @@ bond = (obj, property) ->
 
   previous = obj[property]
 
-  if !previous?
-    throw new Error("Could not find property #{property}.")
-
   registerRestore = ->
     allStubs.push restore
   restore = ->

--- a/bond.js
+++ b/bond.js
@@ -107,8 +107,6 @@ void function () {
     if (arguments.length === 0)
       return createAnonymousSpy();
     previous = obj[property];
-    if (!(null != previous))
-      throw new Error('Could not find property ' + property + '.');
     registerRestore = function () {
       return allStubs.push(restore);
     };

--- a/test.coffee
+++ b/test.coffee
@@ -170,15 +170,6 @@ describe 'bond', ->
       result = math.add(1, 2)
       equal result, 123
 
-    it 'reports missing properties', ->
-      errorMessage = null
-      try
-        bond(math, 'non-existant').through()
-      catch e
-        errorMessage = e.message
-
-      equal errorMessage, 'Could not find property non-existant.'
-
     it 'records call count via called', ->
       bond(math, 'add').return(777)
       equal math.add.called, 0


### PR DESCRIPTION
I'd like to be able to define an expected stubbed response on properties that may not be defined at the time I'm stubbing them (i.e. in a beforeEach block, or at the beginning of a test for clarity). It'd be nice to just not catch these errors, and allow properties to be stubbed.
