### PR TITLE
update CSR usage to use /register

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,4 +10,4 @@ compile:
 .PHONY: test
 
 test:
-	$(MOCHA) --compilers coffee:coffee-script-redux --reporter spec --colors test.coffee
+	$(MOCHA) --compilers coffee:coffee-script-redux/register --reporter spec --colors test.coffee


### PR DESCRIPTION
At a certain point, coffee-script-redux changed how you register the coffee extension. This uses the new format.
