### PR TITLE
force consumer to call cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
-bond: the simple stub/spy javascript library
-===
+# bond: the simple stub/spy javascript library
 
 bond only provides stubbing and spy functionality. For test running and assertions, you will need to use other libraries.
 
-bond api
-====
+## bond api
 
 `bond(object, 'propertyOrMethodName')` returns the bond api
 
@@ -22,8 +20,7 @@ bond api
 
 `bond#restore()` replaces a spy/stub with its original value; useful for implementing your own `cleanup` handler (see below)
 
-bond spies
-====
+## bond spies
 
 `spy.called` is a call count for the spy
 
@@ -31,28 +28,22 @@ bond spies
 
 `spy.calledArgs` is an array of methods calls, each index holds the array of arguments for that call
 
-usage
-===
+## usage
 
 `npm install bondjs` -> `bond = require 'bondjs'`
 
 `<script src="bond.js">` -> `window.bond(...)`
 
-**with mocha, qunit, jasmine**: These frameworks should work with bond as is. Bond looks for a global function named either `afterEach` or `testDone` to implement its spy/stub restore functionality. If those exist, as they should when using these frameworks, it should work fine.
+You must also add the equivalent of a global `afterEach` callback that calls `bond.cleanup()`.
+This will restore all spies made by bond.
 
-**with some other test runner**: You may need to implement your own `cleanup` method for bond to work properly. This might look like the following.
-
-`bond.cleanup = someTestRunner.registerAfterCallback`
-
-tests
-===
+## tests
 
 see the `test.coffee` file for examples
 
-use `npm test` to run the tests
+use `make test` to run the tests
 
-
-license
-===
+## license
 
 MIT
+

--- a/bond.coffee
+++ b/bond.coffee
@@ -62,7 +62,6 @@ arrayEqual = (A, B) ->
 
   true
 
-
 nextTick = do ->
   return process.nextTick if isFunction(process?.nextTick)
   return setImmediate if setImmediate? && isFunction(setImmediate)
@@ -70,16 +69,11 @@ nextTick = do ->
   (fn) ->
     setTimeout(fn, 0)
 
-
 allStubs = []
-do registerCleanupHook = ->
-  after = afterEach ? testDone ? this.cleanup ? ->
-    throw new Error('bond.cleanup must be specified if your test runner does not use afterEach or testDone')
-
-  after ->
-    for stubRestore in allStubs
-      stubRestore()
-    allStubs = []
+cleanup = ->
+  for stubRestore in allStubs
+    stubRestore()
+  allStubs = []
 
 bond = (obj, property) ->
   return createAnonymousSpy() if arguments.length == 0
@@ -126,7 +120,7 @@ bond = (obj, property) ->
     'restore': restore
   }
 
-bond.version = '0.0.13'
+bond.cleanup = cleanup
 
 window.bond = bond if window?
 module.exports = bond if module?.exports


### PR DESCRIPTION
I never liked that bond would know to call the global `afterEach` methods of different test frameworks. This change forces the consumer of bond to set up their own `afterEach` event that calls `bond.cleanup()`.

This will make bond setup a bit more troublesome, but bond integration becomes much easier.
