### PR TITLE
Fix npm 1.3.21 warning "No repository field."

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "bondjs",
   "version": "1.0.0",
   "description": "simple js stub/spy library",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/EndangeredMassa/bond"
+  },
   "main": "lib/bond.js",
   "author": "Sean Massa <endangeredmassa@gmail.com>",
   "scripts": {


### PR DESCRIPTION
This gets rid of modern `npm install` warnings like this one:

![bond-warning](https://f.cloud.github.com/assets/2459/2257937/49c4fa7a-9e21-11e3-973f-a98de4b091b2.png)
