### PR TITLE
Make calledWith match any call, not just the most recent

### DIFF
--- a/bond.coffee
+++ b/bond.coffee
@@ -47,9 +47,9 @@ enhanceSpy = (spy, original, bondApi) ->
   spy.called = 0
   spy.calledArgs = []
   spy.calledWith = (args...) ->
-    return false if !spy.called
-    lastArgs = spy.calledArgs[spy.called-1]
-    arrayEqual(args, lastArgs)
+    for calledArgs in spy.calledArgs
+      return true if arrayEqual(args, calledArgs)
+    false
 
   spy[k] = v for k, v of bondApi if bondApi
 

--- a/lib/bond.js
+++ b/lib/bond.js
@@ -53,12 +53,14 @@ void function () {
     spy.called = 0;
     spy.calledArgs = [];
     spy.calledWith = function (args) {
-      var lastArgs;
+      var calledArgs;
       args = 1 <= arguments.length ? [].slice.call(arguments, 0) : [];
-      if (!spy.called)
-        return false;
-      lastArgs = spy.calledArgs[spy.called - 1];
-      return arrayEqual(args, lastArgs);
+      for (var i$ = 0, length$ = spy.calledArgs.length; i$ < length$; ++i$) {
+        calledArgs = spy.calledArgs[i$];
+        if (arrayEqual(args, calledArgs))
+          return true;
+      }
+      return false;
     };
     if (bondApi)
       for (k in bondApi) {

--- a/test.coffee
+++ b/test.coffee
@@ -222,11 +222,18 @@ describe 'bond', ->
       math.add(1, 2)
       expect math.add.called
 
-    it 'responds to calledWith(args...)', ->
-      bond(math, 'add').return(666)
-      expect !math.add.calledWith(11, 22)
-      math.add(11, 22)
-      expect math.add.calledWith(11, 22)
+    describe 'calledWith', ->
+      it 'returns whether the method has been called', ->
+        bond(math, 'add').return(666)
+        expect !math.add.calledWith(11, 22)
+        math.add(11, 22)
+        expect math.add.calledWith(11, 22)
+
+      it 'returns true when the arguments are not from the most recent call', ->
+        bond(math, 'add').return(666)
+        math.add(11, 22)
+        math.add(33, 44)
+        expect math.add.calledWith(11, 22)
 
     it 'exposes argsForCall', ->
       bond(math, 'add').return(555)


### PR DESCRIPTION
Previously, `bond().calledWith(args...)` only matched the most recent call to the spy. Now, it matches any call. Not sure if this is desired behavior, so wanted to get your thoughts. (I could also make it another method if you want to keep the `calledWith` API the same—something like `everCalledWith()`.)